### PR TITLE
Merge miniver upstream modifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,9 +43,9 @@ so that Miniver reports a reasonable version.
 
 If your project uses *unannotated tags* for versioning (though this is not the
 [recommended way](https://stackoverflow.com/questions/11514075/what-is-the-difference-between-an-annotated-and-unannotated-tag))
-then you'll need to run the following in order to modify Miniver's behaviour:
+then you'll need to run the following in order to modify Miniver2's behaviour:
 ```
-curl https://raw.githubusercontent.com/jbweston/miniver/master/unannotated-tags.patch | patch <your_package_directory>/_version.py
+curl https://raw.githubusercontent.com/cmarquardt/miniver2/master/unannotated-tags.patch | patch <your_package_directory>/_version.py
 ```
 
 ### I don't want to type that URL every time I use this

--- a/README.md
+++ b/README.md
@@ -36,6 +36,18 @@ curl https://raw.githubusercontent.com/cmarquardt/miniver2/master/install-minive
 ```
 This will grab the latest files from GitHub and set up Miniver2 for your project.
 
+### I get an `unknown` version!
+The version is reported as `unknown` (plus the current git hash) when there are no valid tags
+in the git history. You should create an [*annotated tag*](https://git-scm.com/book/en/v2/Git-Basics-Tagging)
+so that Miniver reports a reasonable version.
+
+If your project uses *unannotated tags* for versioning (though this is not the
+[recommended way](https://stackoverflow.com/questions/11514075/what-is-the-difference-between-an-annotated-and-unannotated-tag))
+then you'll need to run the following in order to modify Miniver's behaviour:
+```
+curl https://raw.githubusercontent.com/jbweston/miniver/master/unannotated-tags.patch | patch <your_package_directory>/_version.py
+```
+
 ### I don't want to type that URL every time I use this
 You can clone (or download a `.zip` containing) this repository and run
 `python setup.py install`, which will give you the `install-miniver` script.

--- a/install-miniver2
+++ b/install-miniver2
@@ -20,7 +20,7 @@ except ImportError:
     _miniver_is_installed = False
 
 # When we fetch miniver from local files
-_miniver_modules = ('_version', '_static_version')
+_miniver_modules = ('_version',)
 
 
 # When we fetch miniver from GitHub
@@ -54,6 +54,21 @@ _setup_template = '''
     )
 '''
 
+_static_version_template = textwrap.dedent('''\
+    # -*- coding: utf-8 -*-
+    # This file is part of 'miniver': https://github.com/jbweston/miniver
+    #
+    # This file will be overwritten by setup.py when a source or binary
+    # distribution is made.  The magic value "__use_git__" is interpreted by
+    # version.py.
+
+    version = "__use_git__"
+
+    # These values are only set if the distribution was created with 'git archive'
+    refnames = "$Format:%D$"
+    git_hash = "$Format:%h$"
+''')
+
 _init_template = 'from ._version import __version__'
 _gitattribute_template = '{package_dir}/_static_version.py export-subst'
 
@@ -76,6 +91,11 @@ def _write_line(content, filename):
     if not _line_in_file(content, filename):
         with open(filename, 'a') as f:
             f.write(content)
+
+
+def _write_content(content, filename):
+    with open(filename, 'w') as f:
+        f.write(content)
 
 
 def _fail(msg):
@@ -130,6 +150,8 @@ def main():
     # Write content to local package directory
     for path, output_path in zip(miniver_paths, output_paths):
         shutil.copy(path, output_path)
+    _write_content(_static_version_template,
+                   os.path.join(package_dir, '_static_version.py'))
     _write_line(_gitattribute_template.format(package_dir=package_dir),
                 '.gitattributes')
     _write_line(_init_template.format(package_dir=package_dir),

--- a/install-miniver2
+++ b/install-miniver2
@@ -18,6 +18,7 @@ try:
     del miniver2
     _miniver_is_installed = True
 except ImportError:
+    _miniver_version = 'unknown'
     _miniver_is_installed = False
 
 # When we fetch miniver from local files

--- a/install-miniver2
+++ b/install-miniver2
@@ -14,6 +14,7 @@ from urllib.request import urlretrieve
 
 try:
     import miniver2
+    _miniver_version = miniver2.__version__
     del miniver2
     _miniver_is_installed = True
 except ImportError:
@@ -122,7 +123,13 @@ def extract_miniver_from_local():
 
 def get_args():
     parser = argparse.ArgumentParser(
+<<<<<<< HEAD:install-miniver2
         description="Install 'miniver2' into the current Python package")
+=======
+        description="Install 'miniver' into the current Python package")
+    parser.add_argument("-v", "--version", action="version",
+                        version=_miniver_version)
+>>>>>>> 1a77c48... add --version flag to the install-miniver script:install-miniver
     parser.add_argument('package_directory',
                         help="Directory to install 'miniver2' into.")
     return parser.parse_args().package_directory

--- a/miniver2/__init__.py
+++ b/miniver2/__init__.py
@@ -1,2 +1,3 @@
+__all__ = ['__version__']
 from ._version import __version__
-del _version
+del _version  # remove to avoid confusion with __version__

--- a/miniver2/_version.py
+++ b/miniver2/_version.py
@@ -94,7 +94,8 @@ def get_version_from_git():
     try:
         release, dev, git = description
     except ValueError:  # No tags, only the git hash
-        git, = description
+        # prepend 'g' to match with format returned by 'git describe'
+        git = 'g%s' % description
         release = 'unknown'
         dev = None
 

--- a/miniver2/_version.py
+++ b/miniver2/_version.py
@@ -4,7 +4,6 @@
 from collections import namedtuple
 import os
 import subprocess
-import sys
 
 from distutils.command.build_py import build_py as build_py_orig
 from setuptools.command.sdist import sdist as sdist_orig

--- a/miniver2/_version.py
+++ b/miniver2/_version.py
@@ -73,9 +73,10 @@ def get_version_from_git():
     # that were merged-in.
     for opts in [['--first-parent'], []]:
         try:
-            p = subprocess.Popen(['git', 'describe', '--long'] + opts,
-                                 cwd=distr_root,
-                                 stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            p = subprocess.Popen(
+                ['git', 'describe', '--long'] + opts,
+                cwd=distr_root,
+                stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         except OSError:
             return
         if p.wait() == 0:
@@ -94,7 +95,7 @@ def get_version_from_git():
     try:
         p = subprocess.Popen(['git', 'diff', '--quiet'], cwd=distr_root)
     except OSError:
-        labels.append('confused') # This should never happen.
+        labels.append('confused')  # This should never happen.
     else:
         if p.wait() == 1:
             labels.append('dirty')
@@ -131,6 +132,7 @@ def get_version_from_git_archive(version_info):
 
 
 __version__ = get_version()
+
 
 # The following section defines a module global 'cmdclass',
 # which can be used from setup.py. The 'package_name' and

--- a/miniver2/_version.py
+++ b/miniver2/_version.py
@@ -167,7 +167,7 @@ def _write_version(fname):
 # Python 2; and calling super() with arguments is another workaround in order
 # to support Python 2.
 
-class _build(build_py_orig, object):
+class _build_py(build_py_orig, object):
     def run(self):
         super(_build, self).run()
         _write_version(os.path.join(self.build_lib, package_name,

--- a/miniver2/_version.py
+++ b/miniver2/_version.py
@@ -6,7 +6,7 @@ import os
 import subprocess
 import sys
 
-from distutils.command.build import build as build_orig
+from distutils.command.build_py import build_py as build_py_orig
 from setuptools.command.sdist import sdist as sdist_orig
 
 Version = namedtuple('Version', ('release', 'dev', 'labels'))
@@ -153,7 +153,7 @@ def _write_version(fname):
 # Python 2; and calling super() with arguments is another workaround in order
 # to support Python 2.
 
-class _build(build_orig, object):
+class _build(build_py_orig, object):
     def run(self):
         super(_build, self).run()
         _write_version(os.path.join(self.build_lib, package_name,
@@ -167,4 +167,4 @@ class _sdist(sdist_orig, object):
                                     STATIC_VERSION_FILE))
 
 
-cmdclass = dict(sdist=_sdist, build=_build)
+cmdclass = dict(sdist=_sdist, build_py=_build_py)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[metadata]
+license_file = LICENSE

--- a/setup.py
+++ b/setup.py
@@ -23,10 +23,14 @@ def get_version_and_cmdclass(package_name):
 
 version, cmdclass = get_version_and_cmdclass('miniver2')
 
+with open('README.md') as readme_file:
+    long_description = readme_file.read()
 
 setup(
     name='miniver2',
     description='minimal versioning tool',
+    long_description=long_description,
+    long_description_content_type='text/markdown',
     version=version,
     url='https://github.com/cmarquardt/miniver2',
     author='Christian Marquardt (original: Joseph Weston and Christoph Groth)',

--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,7 @@ import os
 import sys
 
 
+
 # Loads version.py module without importing the whole package.
 def get_version_and_cmdclass(package_name):
     try: # Python 3

--- a/unannotated-tags.patch
+++ b/unannotated-tags.patch
@@ -1,0 +1,11 @@
+Apply this patch to '_version.py' to get Miniver to calculate
+the version using unannotated tags in addition to annotated tags
+@@ -75,7 +75,7 @@ def get_version_from_git():
+     for opts in [['--first-parent'], []]:
+         try:
+             p = subprocess.Popen(
+-                ['git', 'describe', '--long', '--always'] + opts,
++                ['git', 'describe', '--long', '--always', '--tags'] + opts,
+                 cwd=distr_root,
+                 stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+         except OSError:


### PR DESCRIPTION
 - Modifications as implemented upstream until 06 August 2018 (up to v0.3.0, v0.3.1, with a few additional commits);
 - Added tags to identify equivalent versions. Note that upstrean uses `vX.Y.Z`; `miniver2` uses `X.Y.Z` instead.